### PR TITLE
Yaz0圧縮の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/ARCTool/MEMO.md

--- a/ARCTool/FileSys/Format_Checker.cs
+++ b/ARCTool/FileSys/Format_Checker.cs
@@ -30,7 +30,7 @@ namespace ARCTool.FileSys
             else if (Magic == "Yaz0")
             {
                 //Console.WriteLine("Yaz0が含まれたRARCはまだ未対応です");
-                Yaz0.Decord(rarc_path);
+                Yaz0.Decode(rarc_path);
                 Console.WriteLine("Yaz0End");
                 var savedirectory = rarc_path.Substring(0, rarc_path.LastIndexOf(@"\"));
                 var savefilename = Path.GetFileNameWithoutExtension(rarc_path) + ".rarc";

--- a/ARCTool/FileSys/RARC.cs
+++ b/ARCTool/FileSys/RARC.cs
@@ -69,7 +69,7 @@ namespace ARCTool.FileSys
         private static List<DirectoryItemInfo> Directory_Items;
         private static List<DirectoryPathInfo> DirectoryPaths;
 
-        public class HeaderData 
+        public class HeaderData
         {
             public string Magic { get; set; }
             public int FileSize { get; set; }
@@ -81,8 +81,8 @@ namespace ARCTool.FileSys
             public int Unknown3 { get; set; }
 
             public const int HeaderSize = 0x20;
-            
-            public void Read(BinaryReader br) 
+
+            public void Read(BinaryReader br)
             {
                 Magic = CS.Byte2Char(br);
                 FileSize = CS.Byte2Int(br);
@@ -95,7 +95,7 @@ namespace ARCTool.FileSys
             }
         }
 
-        public class InformationData 
+        public class InformationData
         {
             public int NodeLength { get; set; }
             public int FirstNodeOffset { get; set; }
@@ -107,7 +107,7 @@ namespace ARCTool.FileSys
             public short Unknown4 { get; set; }
             public int Unknown5 { get; set; }
 
-            public void Read(BinaryReader br) 
+            public void Read(BinaryReader br)
             {
                 NodeLength = CS.Byte2Int(br);
                 FirstNodeOffset = CS.Byte2Int(br);
@@ -121,23 +121,23 @@ namespace ARCTool.FileSys
             }
         }
 
-        public class FileSectionDataPosition 
+        public class FileSectionDataPosition
         {
             public long BaseAddress { get; private set; }
             public long EndAddress { get; private set; }
 
-            public void Set_BaseAddress(int fileDataOffset) 
+            public void Set_BaseAddress(int fileDataOffset)
             {
                 BaseAddress = fileDataOffset + HeaderData.HeaderSize;
             }
 
-            public void Set_EndAddress(int fileDataLength_1) 
+            public void Set_EndAddress(int fileDataLength_1)
             {
                 EndAddress = BaseAddress + fileDataLength_1;
             }
         }
 
-        public class NodeInformation 
+        public class NodeInformation
         {
             public string ID { get; private set; }
             public int StringTopOffset { get; private set; }
@@ -145,7 +145,7 @@ namespace ARCTool.FileSys
             public short FolderDirectoryCount { get; private set; }
             public int FirstDirectoryIndex { get; private set; }
 
-            public static NodeInformation Read(BinaryReader br) 
+            public static NodeInformation Read(BinaryReader br)
             {
                 return new NodeInformation
                 {
@@ -158,11 +158,11 @@ namespace ARCTool.FileSys
             }
         }
 
-        public class NodeSectionData 
+        public class NodeSectionData
         {
             public List<NodeInformation> Data;
 
-            public NodeSectionData() 
+            public NodeSectionData()
             {
                 Data = new List<NodeInformation>();
             }
@@ -341,7 +341,7 @@ namespace ARCTool.FileSys
                                         DirectoryPaths.Add(thisdir);
                                         Directory.CreateDirectory(thisdir.Path);
                                     }
-                                    else 
+                                    else
                                     {
                                         //thisdir.Path = Directory.GetParent(thisdir.Path).FullName;
                                         DirectoryPaths.Add(thisdir);
@@ -453,7 +453,7 @@ namespace ARCTool.FileSys
                 var file = Directory.GetFiles(dirName, "*", SearchOption.TopDirectoryOnly).Length;
                 Console.WriteLine($"dir{dir}:file{file}");
                 if ((dir + file) < 3) {
-                    
+
                     HasTwoDepth = false;
                     break;
                 }
@@ -495,11 +495,11 @@ namespace ARCTool.FileSys
                         //Console.ReadKey();
                         HasOneDepth = true;
                         //break;
-                        
-                    } 
+
+                    }
                     continue;
                 }
-                
+
                 var ParentDirectory1Upper = Directory.GetParent(DirectoryPath.Value);
                 var ParentDirectory2Upper = Directory.GetParent(ParentDirectory1Upper.FullName);
                 bool HasDepth1 = ParentDirectory1Upper.FullName == RootDirectoryPath;
@@ -509,7 +509,7 @@ namespace ARCTool.FileSys
                     HasOneDepth = true;
                     ////break;
                 }
-                
+
 
                 Console.WriteLine(DirectoryPath.Value);
                 Console.WriteLine("↓↓↓↓↓↓↓↓↓");
@@ -587,6 +587,12 @@ namespace ARCTool.FileSys
         {
             FileStream fs = new(extractPath, FileMode.Create);
             BinaryWriter bw = new(fs);
+            Archive(bw, dirstrs, filestrs);
+            bw.Close();
+        }
+
+        public void Archive(BinaryWriter bw, string[] dirstrs, string[] filestrs)
+        {
             Directory_Items = new List<DirectoryItemInfo>();
 
             long pos_File_Size = 0x4;
@@ -616,7 +622,7 @@ namespace ARCTool.FileSys
             CS.String_Writer_Int(bw, Sum_IDIC);
             CS.String_Writer_Int(bw, FileEntryOffset);
             //0x30
-            var pos_StringTable = fs.Position;
+            var pos_StringTable = bw.BaseStream.Position;
             CS.Null_Writer_Int32(bw, 2);
             CS.String_Writer_Int(bw, AllFileCount);
             CS.String_Writer_Int(bw, DirectoryDepth_LessThan2);//
@@ -645,26 +651,24 @@ namespace ARCTool.FileSys
                 bw = bw
             };
             var FileEntrySectionItemNum = RARCNS.Write();
-            PaddingWriter(fs, bw);
+            PaddingWriter(bw.BaseStream, bw);
 
-            var pos_nulldataold = fs.Position;
+            var pos_nulldataold = bw.BaseStream.Position;
             for (var i = 0; i < FileEntrySectionItemNum; i++)
                 NullDataWriter(bw);
-            PaddingWriter(fs, bw);
+            PaddingWriter(bw.BaseStream, bw);
 
-            var pos_StringDataTop = fs.Position;
+            var pos_StringDataTop = bw.BaseStream.Position;
             bw.Write(ms.ToArray());
-            PaddingWriter(fs, bw);
-            var pos_FileDataTop = fs.Position;
+            PaddingWriter(bw.BaseStream, bw);
+            var pos_FileDataTop = bw.BaseStream.Position;
 
 
 
-            fs.Seek(pos_nulldataold, SeekOrigin.Begin);
+            bw.BaseStream.Seek(pos_nulldataold, SeekOrigin.Begin);
 
 
             //FileEntrySection
-            var currentfolder = extractPath.Substring(0, extractPath.Count() - 4);
-            //Console.WriteLine(currentfolder);
             string[] dirnode;
             string[] filenode;
             var filesizetotal = 0;
@@ -723,10 +727,10 @@ namespace ARCTool.FileSys
                         CS.String_Writer_Int(bw, 0x00000000);
 
                         //fileWriter
-                        var pos_before_filedata_write = fs.Position;
-                        fs.Seek(pos_FileDataTop + filesizetotal, SeekOrigin.Begin);
+                        var pos_before_filedata_write = bw.BaseStream.Position;
+                        bw.BaseStream.Seek(pos_FileDataTop + filesizetotal, SeekOrigin.Begin);
                         bw.Write(File.ReadAllBytes(sorted_dirConcatfile[i]));
-                        fs.Seek(pos_before_filedata_write, SeekOrigin.Begin);
+                        bw.BaseStream.Seek(pos_before_filedata_write, SeekOrigin.Begin);
 
                         testfilenum++;
 
@@ -775,31 +779,27 @@ namespace ARCTool.FileSys
                 //}
             }
 
-            fs.Seek(fs.Length, SeekOrigin.Begin);
-            PaddingWriter(fs, bw);
+            bw.BaseStream.Seek(bw.BaseStream.Length, SeekOrigin.Begin);
+            PaddingWriter(bw.BaseStream, bw);
 
             //Console.WriteLine(CS.ARC_Hash(".."));
 
             //ファイルサイズを書き込む
-            fs.Seek(pos_File_Size, SeekOrigin.Begin);
-            CS.String_Writer_Int(bw, (int)fs.Length);
+            bw.BaseStream.Seek(pos_File_Size, SeekOrigin.Begin);
+            CS.String_Writer_Int(bw, (int)bw.BaseStream.Length);
 
             //ファイルデータセクションのオフセットとサイズを書き込む
-            fs.Seek(pos_FileDataSection, SeekOrigin.Begin);
+            bw.BaseStream.Seek(pos_FileDataSection, SeekOrigin.Begin);
             CS.String_Writer_Int(bw, (int)(pos_FileDataTop - 0x20));
-            CS.String_Writer_Int(bw, (int)(fs.Length - pos_FileDataTop));
-            CS.String_Writer_Int(bw, (int)(fs.Length - pos_FileDataTop));
+            CS.String_Writer_Int(bw, (int)(bw.BaseStream.Length - pos_FileDataTop));
+            CS.String_Writer_Int(bw, (int)(bw.BaseStream.Length - pos_FileDataTop));
 
             //文字列テーブルのセクションサイズとオフセット
-            fs.Seek(pos_StringTable, SeekOrigin.Begin);
+            bw.BaseStream.Seek(pos_StringTable, SeekOrigin.Begin);
             CS.String_Writer_Int(bw, (int)(pos_FileDataTop - pos_StringDataTop));
             CS.String_Writer_Int(bw, (int)(pos_StringDataTop - 0x20));
 
             //Console.WriteLine("RARC_End");
-
-            //fs,bw終了処理
-            fs.Close();
-            bw.Close();
         }
 
 
@@ -827,7 +827,7 @@ namespace ARCTool.FileSys
         /// <return>戻り値：なし</return>
         /// </summary>
         /// <remarks>圧縮専用</remarks>
-        public static void PaddingWriter(FileStream fs, BinaryWriter bw)
+        public static void PaddingWriter(Stream fs, BinaryWriter bw)
         {
             if (fs.Position % 32f != 0)
             {

--- a/ARCTool/FileSys/Yaz0.cs
+++ b/ARCTool/FileSys/Yaz0.cs
@@ -230,26 +230,33 @@ namespace ARCTool.FileSys
             bw.Write(NewBytes, sindex, eindex);
         }
 
-        public void Encode2(string encodeFilePath, BinaryReader br)
+        private void HeaderWriter(BinaryWriter bw, long RawSize)
         {
-            FileStream fs = new(encodeFilePath, FileMode.Create);
-            Encode2(new BinaryWriter(fs), br);
-            fs.Close();
-        }
-
-        public void Encode2(BinaryWriter bw, BinaryReader br)
-        {
-            var DictionaryList = new List<byte>();
-
-
-            //ヘッダー情報の書き込み
             CS.String_Writer(bw, Magic);
             var buf = new byte[4];
-            BinaryPrimitives.WriteUInt32BigEndian(buf, (uint)br.BaseStream.Length);
+            BinaryPrimitives.WriteUInt32BigEndian(buf, (uint)RawSize);
             bw.Write(buf);
             CS.Null_Writer_Int32(bw, 2);
+        }
 
-            Console.WriteLine("header end");
+        private static void PaddingWriter(BinaryWriter bw)
+        {
+            const int Pack_Length = sizeof(Int32) * 4;
+            var mod = bw.BaseStream.Length % Pack_Length;
+            byte[] padding = new byte[Pack_Length - mod];
+
+            if (padding.Length != 0)
+            {
+                padding[0] = 0xFF;
+                bw.Write(padding);
+            }
+        }
+
+        public void EncodeOptimize(BinaryWriter bw, BinaryReader br)
+        {
+            //ヘッダー情報の書き込み
+            Console.WriteLine("write header");
+            HeaderWriter(bw, br.BaseStream.Length);
 
             Console.WriteLine("write chunk");
 
@@ -272,28 +279,57 @@ namespace ARCTool.FileSys
                 chunk = new Yaz0ChunkEncode(ref buffer);
                 bw.Write(chunk.GetValue());
             }
-            if (buffer.Count() > 0)
+            if (buffer.Count > 0)
             {
                 chunk = new Yaz0ChunkEncode(ref buffer);
                 bw.Write(chunk.GetValue());
             }
             //チャンクデータの読み込み方法を設定_END
 
-            const int Pack_Length = sizeof(Int32) * 4;
-            var mod = bw.BaseStream.Length % Pack_Length;
-            byte[] padding = new byte[Pack_Length - mod];
+            Console.WriteLine("write padding");
+            PaddingWriter(bw);
 
-            if (padding.Length != 0)
+            Console.WriteLine($"Stream End Pos: {br.BaseStream.Position}");
+        }
+        public void EncodeOptimize(string encodeFilePath, BinaryReader br)
             {
-                padding[0] = 0xFF;
-                bw.Write(padding);
-            }
-
-            Console.WriteLine(br.BaseStream.Position);
-            Console.ReadKey();
+            FileStream fs = new(encodeFilePath, FileMode.Create);
+            EncodeOptimize(new BinaryWriter(fs), br);
+            fs.Close();
         }
 
-        public void Encode(string encodeFilePath)
+        public void Encode(BinaryWriter bw, BinaryReader br)
+        {
+            Console.WriteLine("write header");
+            HeaderWriter(bw, br.BaseStream.Length);
+
+            Console.WriteLine("write chunk");
+            Yaz0Chunk chunk = new Yaz0ChunkRawEncode(br);
+            bw.Write(chunk.GetValue());
+
+            while (br.BaseStream.Position < br.BaseStream.Length)
+            {
+                chunk = new Yaz0ChunkEncode(br);
+                bw.Write(chunk.GetValue());
+            }
+
+            Console.WriteLine("write padding");
+            PaddingWriter(bw);
+
+            Console.WriteLine($"Stream End Pos: {br.BaseStream.Position}");
+            }
+
+        public void Encode(string encodeFilePath, BinaryReader br)
+        {
+            FileStream fs = new(encodeFilePath, FileMode.Create);
+            Encode(new BinaryWriter(fs), br);
+            fs.Close();
+        }
+
+
+
+        // TODO: 必要か？
+        public void EncodeOld(string encodeFilePath)
         {
             var Yaz0_FullPath = Path.ChangeExtension(encodeFilePath, ".arc");
 
@@ -778,14 +814,40 @@ namespace ARCTool.FileSys
         //    Console.ReadKey();
         //}
 
-        public static char Use_Yaz0_Encode()
+        public enum UseStatus
+        {
+            UnUse,
+            Use,
+            UseNew,
+        }
+
+        public static UseStatus Use_Yaz0_Encode()
         {
             Console.WriteLine("全ての項目にYaz0圧縮をしますか？");
             Console.WriteLine("※解凍時は自動でYaz0の処理を実行します。");
-            Console.WriteLine("y Yaz0圧縮を使用　n Yaz0圧縮を使用しない");
+            Console.WriteLine("y Yaz0圧縮を使用　Y Yaz0圧縮(新)を使用 n Yaz0圧縮を使用しない");
 
-            var yesnoChars = Console.ReadLine().ToCharArray();
-            return yesnoChars[0];
+            switch (Console.ReadLine().ToCharArray()[0])
+            {
+                case 'y':
+                case 'ｙ':
+                    return UseStatus.Use;
+                case 'Y':
+                case 'Ｙ':
+                    return UseStatus.UseNew;
+            }
+
+            return UseStatus.UnUse;
+        }
+
+        public static bool Use_Yaz0_Encode_Optimize()
+        {
+            Console.WriteLine("圧縮の最適化を使用しますか？");
+            Console.WriteLine("y 最適化する　n 最適化しない");
+
+            var yesno = Console.ReadLine().ToCharArray()[0];
+
+            return (yesno == 'y') || (yesno == 'ｙ') || (yesno == 'Y') || (yesno == 'Ｙ');
         }
     }
 }

--- a/ARCTool/FileSys/Yaz0.cs
+++ b/ARCTool/FileSys/Yaz0.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.IO;
 using System.Collections;
 using CS = ARCTool.FileSys.Calculation_System;
+using System.Buffers.Binary;
 
 namespace ARCTool.FileSys
 {
@@ -20,18 +21,18 @@ namespace ARCTool.FileSys
         public string Magic
         {
             set => s_magic = value;
-            get 
+            get
             {
                 s_magic = "Yaz0";
-                return s_magic; 
+                return s_magic;
             }
         }
         public int OriginalDataSize { get; set; }
-        public int Unknown1 
+        public int Unknown1
         {
-            set 
+            set
             {
-                if (value != 0x00000000) 
+                if (value != 0x00000000)
                 {
                     Console.WriteLine("Yaz0のUnknown1プロパティで例外が発生しました");
                     Console.WriteLine("下記のエラー内容を最下段のURLに報告してください。");
@@ -40,16 +41,16 @@ namespace ARCTool.FileSys
                     Console.ReadKey();
                     Environment.Exit(0);
                 }
-                s_unknown1 = value; 
+                s_unknown1 = value;
             }
-            get 
+            get
             {
                 s_unknown1 = 0x00000000;
                 return s_unknown1;
             }
-            
+
         }
-        public int Unknown2 
+        public int Unknown2
         {
             set
             {
@@ -72,7 +73,7 @@ namespace ARCTool.FileSys
         }
 
         private readonly Byte[] IsNormalRead = {
-            0b_1000_0000 , 
+            0b_1000_0000 ,
             0b_0100_0000 ,
             0b_0010_0000 ,
             0b_0001_0000 ,
@@ -89,14 +90,14 @@ namespace ARCTool.FileSys
             public ChunkData(bool isRead , List<byte> byteList) {
                 IsNormalRead = isRead;
                 ByteList = new List<byte>(byteList);
-            
+
             }
         }
 
         private ChunkData[] ChunkDatas = new ChunkData[8];
 
         private static List<string> s_debug = new List<string>();
-        public void Decord(string filepath)
+        public void Decode(string filepath)
         {
 
             List<bool> bitlist = new();
@@ -198,7 +199,7 @@ namespace ARCTool.FileSys
             foreach (var str in s_debug)
             {
                 stringBuilder.Append(str);
-                
+
             }
             File.WriteAllText(path + "\\DebugByte.txt", stringBuilder.ToString());
 #endif
@@ -213,7 +214,7 @@ namespace ARCTool.FileSys
             bitlist.Reverse();
             return bitlist;
         }
-        
+
         public static byte[] ArrayReverse(byte[] array)
         {
             Array.Reverse(array);
@@ -229,123 +230,67 @@ namespace ARCTool.FileSys
             bw.Write(NewBytes, sindex, eindex);
         }
 
-        public void Encode2(string encodeFilePath) 
+        public void Encode2(string encodeFilePath, BinaryReader br)
         {
-            const byte OffByOne = 1;
+            FileStream fs = new(encodeFilePath, FileMode.Create);
+            Encode2(new BinaryWriter(fs), br);
+            fs.Close();
+        }
 
-            var Yaz0_FullPath            = Path.ChangeExtension(encodeFilePath, ".arc");
-            var Origin_File_ByteArray    = File.ReadAllBytes(encodeFilePath);
-            var Origin_File_Size         = Origin_File_ByteArray.Length;
-            var DictionaryList           = new List<byte>();
+        public void Encode2(BinaryWriter bw, BinaryReader br)
+        {
+            var DictionaryList = new List<byte>();
 
-            FileStream   fsRARC = new(encodeFilePath, FileMode.Open);
-            BinaryReader brRARC = new(fsRARC);
-            MemoryStream msYaz0 = new();
-            BinaryWriter bwYaz0 = new(msYaz0);
 
             //ヘッダー情報の書き込み
-            CS.String_Writer(bwYaz0, Magic);
-            CS.String_Writer_Int(bwYaz0, Origin_File_Size);
-            CS.Null_Writer_Int32(bwYaz0, 2);
+            CS.String_Writer(bw, Magic);
+            var buf = new byte[4];
+            BinaryPrimitives.WriteUInt32BigEndian(buf, (uint)br.BaseStream.Length);
+            bw.Write(buf);
+            CS.Null_Writer_Int32(bw, 2);
 
             Console.WriteLine("header end");
 
+            Console.WriteLine("write chunk");
+
+            Yaz0Chunk chunk = new Yaz0ChunkRawEncode(br);
+            bw.Write(chunk.GetValue());
+
+            ////チャンクデータの読み込み方法を設定
+            //while (br.BaseStream.Position < br.BaseStream.Length)
+            //{
+            //    chunk = new Yaz0ChunkEncode(br);
+            //    bw.Write(chunk.GetValue());
+            //}
+            ////チャンクデータの読み込み方法を設定_END
+
+            List<Yaz0Unit> buffer = new();
             //チャンクデータの読み込み方法を設定
-            while (fsRARC.Position < Origin_File_Size)
+            while (br.BaseStream.Position < br.BaseStream.Length)
             {
-                //読み込み方法デフォルト値
-                //注意：通常読み込みの場合のみ更新します。
-                byte NormalRead = 0b_0000_0000;
-
-                //読み込みフラグのダミーデータを入れる
-                var Pos_DummyData = msYaz0.Position;
-                bwYaz0.Write((byte)NormalRead);
-
-                Console.WriteLine("dummy end");
-
-                //チャンクデータを書き込む
-                for (var chunkIndex = 0; chunkIndex < 8; chunkIndex++)
-                {
-                    var Pos_SearchDataTop = fsRARC.Position;
-
-                    //ファイル末尾まで残り3バイト以下の処理
-                    if (Origin_File_Size < fsRARC.Position + Read_3Byte)
-                    {
-                        //符号反転して残りのビットフラグをすべて通常読み込みにする。
-                        byte ReversNormalRead = (byte)~NormalRead;
-                        NormalRead += ReversNormalRead;
-
-                        //ファイル末尾までデータをそのまま読み込む
-                        for (var t = fsRARC.Position; t < Origin_File_Size; t++)
-                        {
-                            bwYaz0.Write(brRARC.ReadByte());
-                        }
-                        Console.WriteLine("End");
-                        break;
-                    }
-
-                    //辞書データのサイズを設定する
-                    ushort Dictionary_DataSize;
-                    if ((fsRARC.Position >= 2) && (fsRARC.Position < 0x12))
-                    {
-                        Dictionary_DataSize = Read_3Byte;
-                    }
-                    else if (fsRARC.Position < Dictionary_MaxRange)
-                    {
-                        Dictionary_DataSize = (ushort)(fsRARC.Position + OffByOne);
-                    }
-                    else 
-                    {
-                        Dictionary_DataSize = Dictionary_MaxRange;
-                    }
-
-                    //検索データを抽出
-                    byte[] ByteArray3 = new byte[Dictionary_DataSize];
-                    for (long i = 0; i < Dictionary_DataSize; i++)
-                    {
-                        ByteArray3[i] = brRARC.ReadByte();
-                    }
-
-                    
-
-                    //初回の処理
-                    if (fsRARC.Position == 0)
-                    {
-                        for (long i = 0; i < 3; i++)
-                        {
-                            DictionaryList.Add(ByteArray3[i]);
-                            bwYaz0.Write(ByteArray3[i]);
-                            NormalRead += IsNormalRead[i];
-                        }
-                        chunkIndex = 2;
-                        continue;
-                    }
-
-                    File.WriteAllBytes(Yaz0_FullPath, msYaz0.ToArray());
-                    Console.WriteLine(fsRARC.Position);
-                    Console.ReadKey();
-                    brRARC.Close();
-                    fsRARC.Close();
-                    bwYaz0.Close();
-                    msYaz0.Close();
-                    return;
-
-                    //3Byteを辞書データの末尾から検索する
-                    for (long j = 0; j > -1; j--) { }
-
-                }
-                //チャンクデータを書き込む_END
-
+                buffer = Yaz0ChunkEncode.PreprocessUnit(br, buffer);
+                chunk = new Yaz0ChunkEncode(ref buffer);
+                bw.Write(chunk.GetValue());
+            }
+            if (buffer.Count() > 0)
+            {
+                chunk = new Yaz0ChunkEncode(ref buffer);
+                bw.Write(chunk.GetValue());
             }
             //チャンクデータの読み込み方法を設定_END
 
-            File.WriteAllBytes(Yaz0_FullPath, msYaz0.ToArray());
-            Console.WriteLine(fsRARC.Position);
+            const int Pack_Length = sizeof(Int32) * 4;
+            var mod = bw.BaseStream.Length % Pack_Length;
+            byte[] padding = new byte[Pack_Length - mod];
+
+            if (padding.Length != 0)
+            {
+                padding[0] = 0xFF;
+                bw.Write(padding);
+            }
+
+            Console.WriteLine(br.BaseStream.Position);
             Console.ReadKey();
-            brRARC.Close();
-            fsRARC.Close();
-            bwYaz0.Close();
-            msYaz0.Close();
         }
 
         public void Encode(string encodeFilePath)
@@ -379,14 +324,14 @@ namespace ARCTool.FileSys
                 if (fsRARC.Position >= OriginalFileLength) break ;
 
                 //チャンク先頭の読み込みフラグ
-                byte NormalRead = 0b_0000_0000;             
+                byte NormalRead = 0b_0000_0000;
 
                 //読み込みフラグのダミーデータを入れる
                 var Pos_DummyData = msYaz0.Position;
                 bwYaz0.Write((byte)NormalRead);
 
 
-                List <List<byte>> ChunkList = new();
+                List<List<byte>> ChunkList = new();
                 byte ReadingByte;
 
 
@@ -399,7 +344,7 @@ namespace ARCTool.FileSys
                     //3バイト目までは必ず書き込む
                     if (fsRARC.Position == 0)
                     {
-                        for (var FirstIndex = 0; FirstIndex < 3; FirstIndex++) 
+                        for (var FirstIndex = 0; FirstIndex < 3; FirstIndex++)
                         {
                             ChunkIndex = FirstIndex;
                             NormalRead += IsNormalRead[ChunkIndex];
@@ -413,14 +358,14 @@ namespace ARCTool.FileSys
                     }
 
                     //ファイル末尾まで残り3バイト以下の処理
-                    if (OriginalFileLength < fsRARC.Position + Read_3Byte) 
+                    if (OriginalFileLength < fsRARC.Position + Read_3Byte)
                     {
                         //符号反転して残りのビットフラグをすべて通常読み込みにする。
                         byte ReversNormalRead = (byte)~NormalRead;
                         NormalRead += ReversNormalRead;
-                        
+
                         //ファイル末尾までデータをそのまま読み込む
-                        for (var t = fsRARC.Position; t < OriginalFileLength; t++) 
+                        for (var t = fsRARC.Position; t < OriginalFileLength; t++)
                         {
                             bwYaz0.Write(brRARC.ReadByte());
                         }
@@ -463,10 +408,10 @@ namespace ARCTool.FileSys
 
 
                     bool OldFound = DictionaryFinder_3Byte(ChunkInsideBytes,ResizedDictionaryData,out MatchByteCount);
-                    
+
 
                     //3バイトが見つからなかった場合(通常の処理フラグは1)
-                    if (OldFound == false) 
+                    if (OldFound == false)
                     {
                         //Console.WriteLine("NormalReading");
                         fsRARC.Seek(pos_Byte2nd, SeekOrigin.Begin);
@@ -476,14 +421,14 @@ namespace ARCTool.FileSys
                         DictionaryList.RemoveAt(DictionaryList.Count - 1);
                         NormalRead += IsNormalRead[ChunkIndex];
                         bwYaz0.Write(Byte1st);
-                        
+
                         continue;
                     }
 
                     //ここまでチェック済み
                     if (fsRARC.Position + Dictionary_ReadLength >= OriginalFileLength) break;
 
-                    for (var tmp = 0; tmp < (Dictionary_ReadLength + 1); tmp++) 
+                    for (var tmp = 0; tmp < (Dictionary_ReadLength + 1); tmp++)
                     {
                         byte byteTmp = brRARC.ReadByte();
                         ChunkInsideBytes.Add(byteTmp);
@@ -496,7 +441,7 @@ namespace ARCTool.FileSys
 
 
                     OldFound = DictionaryFinder_FByte(ChunkInsideBytes, ResizedDictionaryData, out MatchByteCount,out MatchByteIndex,fsRARC.Position);
-                    
+
 
 
                     //Fバイトが見つからなかった場合(処理フラグは0)
@@ -515,7 +460,7 @@ namespace ARCTool.FileSys
                     }
                     Console.WriteLine("おーばー");
                     Console.ReadKey();
-                    
+
                     File.WriteAllBytes(Yaz0_FullPath, msYaz0.ToArray());
                     Console.WriteLine(fsRARC.Position);
                     Console.ReadKey();
@@ -530,7 +475,7 @@ namespace ARCTool.FileSys
                 bwYaz0.Write(NormalRead);
                 msYaz0.Seek(msYaz0.Length, SeekOrigin.Begin);
                 continue;
-                
+
                 //ファイル末尾のための処理
                 long SearchDataSize = 0x0F;
                 long DistanceFromEnd = OriginalFileLength - fsRARC.Position;
@@ -538,12 +483,12 @@ namespace ARCTool.FileSys
                 {
                     SearchDataSize = DistanceFromEnd;
                 }
-                
+
 
                 var DictionaryData = new List<byte>();
                 int FindDistance;
                 int MatchCount;
-                for (var j = 0; j < SearchDataSize; j++) 
+                for (var j = 0; j < SearchDataSize; j++)
                 {
                     //3バイト目以降
                     var ByteX = brRARC.ReadByte();
@@ -551,7 +496,7 @@ namespace ARCTool.FileSys
                     long Pos_Now = fsRARC.Position;
 
                     var Find = Array.LastIndexOf(Original_File,ChunkList,(int)ReadingPosition,j+ (int)Read_3Byte);
-                    if (Find == -1) 
+                    if (Find == -1)
                     {
                         ChunkList.RemoveAt((int)Pos_Now - 1);
                         fsRARC.Seek(fsRARC.Position - 1, SeekOrigin.Begin);
@@ -559,9 +504,9 @@ namespace ARCTool.FileSys
                     }
                     FindDistance = Find;
                     MatchCount = ChunkList.Count();
-                    if (FindDistance > 0xF) 
+                    if (FindDistance > 0xF)
                     {
-                        FindDistance = 0; 
+                        FindDistance = 0;
                     }
                 }
 
@@ -571,7 +516,7 @@ namespace ARCTool.FileSys
 
 
                 ////検索したいデータを作成
-                
+
                 if (fsRARC.Position >= OriginalFileLength) break;
 
 
@@ -590,7 +535,7 @@ namespace ARCTool.FileSys
         public static bool DictionaryFinder_3Byte(List<byte> ChunkInsideBytes,byte[] ResizedDictionaryData,out UInt16 findLastIndex) 
         {
             //int tes = 0;
-            
+
             const byte OffByOne = 1;
             bool OldFound = false;
             findLastIndex = 0xFFFF;
@@ -622,15 +567,15 @@ namespace ARCTool.FileSys
                 var isFind2 = ResizedDictionaryData[Index + 1] == ChunkInsideBytes[1];
                 var isFind3 = ResizedDictionaryData[Index + 2] == ChunkInsideBytes[2];
                 bool IsFound = (IsFind1 && isFind2 && isFind3);
-                if (IsFound) 
-                { 
-                    OldFound = true; 
-                    findLastIndex = (UInt16)Index; 
-                    break; 
-                } 
+                if (IsFound)
+                {
+                    OldFound = true;
+                    findLastIndex = (UInt16)Index;
+                    break;
+                }
 
             }
-            
+
 
             return OldFound;
         }
@@ -642,7 +587,7 @@ namespace ARCTool.FileSys
             bool OldFound = false;
             matchByteCount = (UInt16)0x000F;
             matchBtyeIndex = (UInt16)0x0FFF;
-            
+
             for (int Index0 = 0; Index0 < DictionaryMaxLength + OffByOne; Index0++)
             {
                 //DictionaryMaxLengthの数分配列を作成
@@ -657,7 +602,7 @@ namespace ARCTool.FileSys
                         Founds[0] = ResizedDictionaryData[0] == ChunkInsideBytes[0];
                         //Console.WriteLine("Case 0 end");
                     }
-                    else 
+                    else
                     {
                         for (int Index2 = 0; Index2 < Index0; Index2++)
                         {
@@ -672,7 +617,7 @@ namespace ARCTool.FileSys
                     //falseが含まれる場合
                     var FoundsLength = Founds.Length;
                     var IsFound = Founds.Where(value => value == false).ToArray();
-                    
+
                     //Console.WriteLine(IsFound.Length == 0);
                     //if (IsFound.Length != 0) continue;
                     if (IsFound.Length == FoundsLength) continue;

--- a/ARCTool/FileSys/Yaz0Chunk.cs
+++ b/ARCTool/FileSys/Yaz0Chunk.cs
@@ -95,6 +95,7 @@ namespace ARCTool.FileSys
                 {
                     skipCount++;
                     st.BaseStream.Seek(basePos, SeekOrigin.Begin);
+                    // [Count()-1] = [^1]
                     retValue[^1] = new Yaz0UnitEncode(st.ReadByte());
                     continue;
                 }

--- a/ARCTool/FileSys/Yaz0Chunk.cs
+++ b/ARCTool/FileSys/Yaz0Chunk.cs
@@ -1,0 +1,169 @@
+﻿using Microsoft.VisualBasic.FileIO;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ARCTool.FileSys
+{
+    // TODO: ファイル分割
+
+    internal abstract class Yaz0Chunk
+    {
+        protected const int Unit_Size = 8;
+        protected const long Flag_Mask_First = 0b1000_0000;
+
+        private Yaz0Unit[] units;
+
+        protected void Initializer(Yaz0Unit[] units)
+        {
+            Debug.Assert(units.Length == Unit_Size);
+            this.units = units;
+        }
+
+        public byte[] GetValue()
+        {
+            List<byte> retValue = new();
+            retValue.Add(0x00);
+
+
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                retValue.AddRange(units[i].GetValue());
+
+                if (units[i].IsCompress)
+                    continue;
+                retValue[0] |= (byte)(Flag_Mask_First >> i);
+            }
+
+            return retValue.ToArray();
+        }
+    }
+
+    internal class Yaz0ChunkRawEncode : Yaz0Chunk
+    {
+        public Yaz0ChunkRawEncode(BinaryReader st)
+        {
+            var units = new Yaz0Unit[Unit_Size];
+
+
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                if (st.BaseStream.Position < st.BaseStream.Length)
+                {
+                    units[i] = new Yaz0UnitEncode(st.ReadByte());
+                }
+                else
+                {
+                    units[i] = new Yaz0UnitEncode();
+                }
+            }
+
+
+            Initializer(units);
+        }
+    }
+
+    internal class Yaz0ChunkEncode : Yaz0Chunk
+    {
+        public static List<Yaz0Unit> PreprocessUnit(BinaryReader st, in List<Yaz0Unit> beforUnits)
+        {
+            List<Yaz0Unit> retValue = new(beforUnits);
+            Yaz0Unit bufUnit = null;
+            long skipCount = 0;
+
+            for (var basePos = st.BaseStream.Position;
+                (retValue.Count < Unit_Size) && (basePos < st.BaseStream.Length);
+                basePos = st.BaseStream.Position)
+            {
+                if (skipCount > 0)
+                {
+                    retValue.Add(bufUnit);
+                }
+                else
+                {
+                    retValue.Add(new Yaz0UnitEncode(st));
+                }
+                st.BaseStream.Seek(basePos + 1, SeekOrigin.Begin);
+                bufUnit = new Yaz0UnitEncode(st);
+
+                if (bufUnit.Score(skipCount + 1) > retValue.Last().Score(skipCount))
+                {
+                    skipCount++;
+                    st.BaseStream.Seek(basePos, SeekOrigin.Begin);
+                    retValue[^1] = new Yaz0UnitEncode(st.ReadByte());
+                    continue;
+                }
+
+                st.BaseStream.Seek(basePos + retValue.Last().Length, SeekOrigin.Begin);
+                skipCount = 0;
+                continue;
+            }
+
+            return retValue;
+        }
+
+        public Yaz0ChunkEncode(BinaryReader st)
+        {
+            var units = new Yaz0Unit[Unit_Size];
+
+
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                if (st.BaseStream.Position < st.BaseStream.Length)
+                {
+                    units[i] = new Yaz0UnitEncode(st);
+                    continue;
+                }
+                units[i] = new Yaz0UnitEncode();
+            }
+
+
+            Initializer(units);
+        }
+
+        public Yaz0ChunkEncode(ref List<Yaz0Unit> units)
+        {
+            var buf = new Yaz0Unit[Unit_Size];
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                if (i < units.Count())
+                {
+                    buf[i] = units[i];
+                    continue;
+                }
+                buf[i] = new Yaz0UnitEncode();
+            }
+            Initializer(buf);
+
+            units = new(units.ToArray()[Math.Min(Unit_Size, units.Count())..]);
+        }
+    }
+
+    internal class Yaz0ChunkDecode : Yaz0Chunk
+    {
+        public Yaz0ChunkDecode(BinaryReader st)
+        {
+            byte flagResult = st.ReadByte();
+            bool[] flags = new bool[Unit_Size];
+
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                flags[i] = (flagResult & (Flag_Mask_First >> i)) != 0;
+            }
+
+            var units = new Yaz0Unit[Unit_Size];
+
+            foreach (var i in Enumerable.Range(0, Unit_Size))
+            {
+                units[i] = new Yaz0UnitDecode(flags[i], st);
+            }
+
+            Initializer(units);
+        }
+    }
+}

--- a/ARCTool/FileSys/Yaz0Test.cs
+++ b/ARCTool/FileSys/Yaz0Test.cs
@@ -13,7 +13,7 @@ namespace ARCTool.FileSys
     public class AppExecuter
     {
 
-        public static void Start(string filePath) 
+        public static void Start(string filePath)
         {
             var newYaz0Path = Path.ChangeExtension(filePath,".arc");
 
@@ -33,7 +33,7 @@ namespace ARCTool.FileSys
             {
                 FileName = appDirPath+@"\yaz0enc.exe",
                 WorkingDirectory = appDirPath,
-                Arguments = filePath,
+                Arguments = $"\"{filePath}\"",
                 UseShellExecute = false,
                 RedirectStandardError = true,
                 RedirectStandardInput = true,
@@ -52,12 +52,12 @@ namespace ARCTool.FileSys
                 throw new Exception("Yaz0のエンコードで問題が発生しました。");
             }
 
-            if (File.Exists(filePath + ".yaz0")) 
+            if (File.Exists(filePath + ".yaz0"))
             {
                 File.Copy(filePath + ".yaz0", newYaz0Path, true);
                 File.Delete(filePath);
                 File.Delete(filePath + ".yaz0");
-            }    
+            }
             else
                 throw new Exception("rarcファイルがありません");
         }
@@ -70,12 +70,12 @@ namespace ARCTool.FileSys
         private byte[] _originData;
         private int _originDataSize;
 
-        public Yaz0Test() 
+        public Yaz0Test()
         {
-        
+
         }
 
-        public void Encode(string rarcFullPath) 
+        public void Encode(string rarcFullPath)
         {
             _yaz0FullPath = Path.ChangeExtension (rarcFullPath,".arc");
             _originData   = File.ReadAllBytes    (rarcFullPath);
@@ -83,7 +83,7 @@ namespace ARCTool.FileSys
 
             using (MemoryStream ms = new MemoryStream()) 
             {
-                using (BinaryWriter bw = new BinaryWriter(ms)) 
+                using (BinaryWriter bw = new BinaryWriter(ms))
                 {
                     HeaderWrite(bw,_originDataSize);
 
@@ -92,7 +92,7 @@ namespace ARCTool.FileSys
 
                 }
             }
-            
+
         }
 
         private void HeaderWrite(BinaryWriter bw,int rarcSize) 
@@ -103,20 +103,20 @@ namespace ARCTool.FileSys
             bw.Write(0x00000000);
         }
 
-        private void EncodeStart(BinaryWriter bw) 
+        private void EncodeStart(BinaryWriter bw)
         {
-            
 
-            using (MemoryStream ms = new MemoryStream(_originData)) 
+
+            using (MemoryStream ms = new MemoryStream(_originData))
             {
-                using (BinaryReader br = new BinaryReader(ms)) 
+                using (BinaryReader br = new BinaryReader(ms))
                 {
-                
+
                 }
             }
         }
 
-        private void EncodeMain(BinaryWriter bw, BinaryReader br) 
+        private void EncodeMain(BinaryWriter bw, BinaryReader br)
         {
             var pos_StartYaz0Data = bw.BaseStream.Position;
 

--- a/ARCTool/FileSys/Yaz0Unit.cs
+++ b/ARCTool/FileSys/Yaz0Unit.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ARCTool.FileSys
+{
+    // TODO: ファイル分割
+
+    /// <summary>
+    /// 圧縮単位での状態を保持します。
+    /// Unitの状態は1~3byteの形態を取りそれぞれ保持するデータ密度に差があります。
+    /// </summary>
+    internal abstract class Yaz0Unit
+    {
+        protected const int Byte2_Additional_Length = 0x2;
+        protected const int Byte2_Max_Dictionary_Length =
+            (0xF000 >> 12) + Byte2_Additional_Length;              //byte2時の辞書サイズ
+
+        protected const int Byte3_Additional_Length = Byte2_Max_Dictionary_Length + 1;
+        protected const int Byte3_Max_Dictionary_Length =
+            0x0000FF + Byte3_Additional_Length;                    //byte2時の辞書サイズ
+
+        protected const int Max_Dictionary_Offset = 0x0FFF - 0x01; //辞書の最大サイズ
+        protected const int Dictionary_Buffer_Size =
+            Max_Dictionary_Offset + Byte3_Max_Dictionary_Length;   //辞書となる値を格納するためのバッファサイズ
+
+        public long Offset { get; private set; }
+        public long Length { get; private set; }
+        public byte Raw { get; private set; }
+        public bool IsCompress { get; private set; }
+
+        public Int64 Score(long skipCount)
+        {
+            if (!IsCompress)
+                return (Int64)Length - (1 + skipCount);
+
+            if (!IsByte3Encode())
+                return (Int64)Length - (2 + skipCount);
+
+            return (Int64)Length - (3 + skipCount);
+        }
+
+        protected Yaz0Unit()
+        {
+            Offset = 0;
+            Length = 1;
+            Raw = 0;
+            IsCompress = false;
+        }
+
+        protected void Initializer(long offset, long length)
+        {
+            Debug.Assert(length > Byte2_Additional_Length);
+            this.IsCompress = true;
+            this.Offset = offset;
+            this.Length = length;
+            this.Raw = 0;
+        }
+
+        protected void Initializer(byte raw)
+        {
+            this.IsCompress = false;
+            this.Offset = 0;
+            this.Length = 1;
+            this.Raw = raw;
+        }
+
+        private bool IsByte3Encode() => Length > Byte2_Max_Dictionary_Length;
+
+        private byte Encode2ByteLength()
+        {
+            Debug.Assert(Length > Byte2_Additional_Length);
+            var buffer = (Length - Byte2_Additional_Length) << 0x04;
+            if ((buffer & ~0xf0) != 0) throw new Exception("2byteフォーマットを指定しましたが要求された圧縮サイズが大きすぎます。");
+            return (byte)buffer;
+        }
+        private byte[] EncodeOffset()
+        {
+            byte[] buffer = new byte[2];
+            buffer[0] = (byte)((Offset & 0xF00) >> 0x08);
+            buffer[1] = (byte)(Offset & 0xFF);
+            return buffer;
+        }
+        private byte Encode3ByteLength()
+        {
+            Debug.Assert(Length >= Byte3_Additional_Length);
+            var buffer = Length - Byte3_Additional_Length;
+            if ((buffer & ~0xFF) != 0) throw new Exception("3byteフォーマットを指定しましたが要求された圧縮サイズが大きすぎます。");
+            return (byte)buffer;
+        }
+
+        public byte[] GetValue()
+        {
+            byte[] ret_value;
+
+            if (!IsCompress)
+                return new byte[] { Raw };
+
+            var offset = EncodeOffset();
+
+            if (!IsByte3Encode())
+            {
+                ret_value = new byte[2];
+                ret_value[0] = Encode2ByteLength();
+                ret_value[0] |= offset[0];
+                ret_value[1] = offset[1];
+
+                return ret_value;
+
+            }
+
+            ret_value = new byte[3];
+
+            ret_value[0] = offset[0];
+            ret_value[1] = offset[1];
+            ret_value[2] = Encode3ByteLength();
+
+            return ret_value;
+        }
+    }
+
+    internal class Yaz0UnitEncode : Yaz0Unit
+    {
+        public Yaz0UnitEncode() : base() { }
+        public Yaz0UnitEncode(byte raw) => Initializer(raw);
+
+        public Yaz0UnitEncode(BinaryReader br)
+        {
+            var dictionary = new byte[Dictionary_Buffer_Size];
+            List<long> matchOffsetBuffer = new();
+
+            var basePosition = br.BaseStream.Position;
+
+            long dictionaryBaseSize = Math.Min(basePosition, Max_Dictionary_Offset);
+
+            br.BaseStream.Seek(basePosition - dictionaryBaseSize, SeekOrigin.Begin);
+
+            var compressSize = br.BaseStream.Read(dictionary) - dictionaryBaseSize;
+            compressSize = Math.Min(compressSize, Byte3_Max_Dictionary_Length);
+
+            br.BaseStream.Seek(basePosition, SeekOrigin.Begin);
+
+            foreach (var i in Enumerable.Range(0, (int)dictionaryBaseSize))
+            {
+                if (dictionary[i] != dictionary[dictionaryBaseSize])
+                    continue;
+
+                matchOffsetBuffer.Add(i);
+            }
+
+            if (matchOffsetBuffer.Count == 0)
+            {
+                // 辞書に存在しない値
+                Initializer(br.ReadByte());
+                return;
+            }
+
+
+            int currentLength = 0;
+            long currentPos = 0;
+            for (var i = 0; i < matchOffsetBuffer.Count; i++)
+            {
+                long targetDictOffset = matchOffsetBuffer[i];
+
+                int length = 1;
+                while (length < compressSize)
+                {
+                    if (dictionary[targetDictOffset + length] != dictionary[dictionaryBaseSize + length])
+                        break;
+                    length++;
+                }
+
+                if (length < currentLength)
+                    continue;
+
+                currentPos = targetDictOffset;
+                currentLength = length;
+            }
+
+            if (currentLength > Byte2_Additional_Length)
+            {
+                br.BaseStream.Seek(basePosition + currentLength, SeekOrigin.Begin);
+                Initializer((dictionaryBaseSize - 1) - currentPos, currentLength);
+                return;
+            }
+
+            Initializer(br.ReadByte());
+            return;
+        }
+
+    }
+    internal class Yaz0UnitDecode : Yaz0Unit
+    {
+        private static long readByte2RawLength(byte[] unit)
+        {
+            Debug.Assert(unit.Length > 1);
+            // byte = 8it は仕様: https://stackoverflow.com/questions/4883515/in-c-what-is-analogous-to-the-char-bit-from-c-fast-abs
+            return (unit[0] & 0xf0) >> 4;
+        }
+        private static long readOffset(byte[] unit)
+        {
+            Debug.Assert(unit.Length > 1);
+            long upper = (unit[0] & 0x0f) << 8;
+            return upper + unit[1] + 1;
+        }
+        private static long readByte3RawOffset(byte[] unit)
+        {
+            Debug.Assert(unit.Length > 2);
+            return unit[2];
+        }
+
+        public Yaz0UnitDecode(bool isCompress, BinaryReader st)
+        {
+            int readByteResult = 0;
+            if (!isCompress)
+            {
+                readByteResult = st.ReadByte();
+
+                if (readByteResult >= 0) throw new IndexOutOfRangeException("読み込むことのできないStreamを渡されました。");
+
+                Initializer((byte)readByteResult);
+                return;
+            }
+
+            byte[] buffer = new byte[3];
+
+            // seekを抑えるために最初の2byteのみ読み込む
+            st.Read(buffer, 0, 2);
+
+            long offset = readOffset(buffer);
+            long length = readByte2RawLength(buffer);
+
+            if (length != 0)
+            {
+                Initializer(offset, length + Byte2_Additional_Length);
+                return;
+            }
+
+
+            readByteResult = st.ReadByte();
+
+            if (readByteResult >= 0) throw new IndexOutOfRangeException("読み込むことのできないStreamを渡されました。");
+
+            buffer[3] = (byte)readByteResult;
+
+            Initializer(offset, readByte3RawOffset(buffer) + Byte3_Additional_Length);
+        }
+    }
+}

--- a/ARCTool/Program.cs
+++ b/ARCTool/Program.cs
@@ -10,11 +10,12 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 
 
-
 namespace ARCTool
 {
     class Program
     {
+        static bool isUseOtherExefile = false;
+
         private static string[] all_path_strings;
         private static string[] arc_path_strings;
         private static string[] dir_path_strings;
@@ -53,13 +54,15 @@ namespace ARCTool
             //var yesnoChars = Console.ReadLine().ToCharArray();
             //yesno = yesnoChars[0];
 
-            
+
             //Console.WriteLine("全パス2"+all_path_strings.Count());
+
+            Yaz0 yaz0 = new();
 
             var isFirstTime = true;
             foreach (var path in all_path_strings)
             {
-                
+
 
 
                 //Console.WriteLine("圧縮フォルダパス" + path);
@@ -70,7 +73,7 @@ namespace ARCTool
                 }
 
                 var PathReplace = path;
-                
+
                 if (Directory.Exists(PathReplace))
                 {
                     if (isFirstTime)
@@ -87,7 +90,7 @@ namespace ARCTool
                     if (DirStrs.Length < 1) continue;
                     if (FileStrs.Length < 1) continue;
 
-                    
+
                     var arcfile = Path.GetFileName(PathReplace);
                     var arcfolder = Path.GetDirectoryName(PathReplace);
 
@@ -96,12 +99,29 @@ namespace ARCTool
                     var ArcExtractPath = arcfolder + @"\" + arcfile;
                     if (yesno == 'y' || yesno == 'Y' || yesno == 'ｙ' || yesno == 'Ｙ')
                     {
-                        rarc.Archive(ArcExtractPath + ".rarc", DirStrs, FileStrs);
-                        Console.WriteLine("yaz0処理に入りました");
-                        Console.WriteLine("圧縮中・・・");
-                        AppExecuter.Start(arcfolder + @"\" + arcfile + ".rarc");
-                        //Yaz0 yaz0 = new();
-                        //yaz0.Encode2(arcfolder + @"\" + arcfile + ".rarc");
+                        if (isUseOtherExefile)
+                        {
+                            rarc.Archive(ArcExtractPath + ".rarc", DirStrs, FileStrs);
+                            Console.WriteLine("yaz0処理に入りました");
+                            Console.WriteLine("圧縮中・・・");
+                            AppExecuter.Start(arcfolder + @"\" + arcfile + ".rarc");
+                            //Yaz0 yaz0 = new();
+                            //yaz0.Encode2(arcfolder + @"\" + arcfile + ".rarc");
+                        }
+                        else
+                        {
+                            MemoryStream memst = new();
+
+                            memst.Seek(0, SeekOrigin.Begin);
+                            rarc.Archive(new BinaryWriter(memst), DirStrs, FileStrs);
+                            Console.WriteLine("yaz0処理に入りました");
+                            Console.WriteLine("圧縮中・・・");
+
+                            memst.Seek(0, SeekOrigin.Begin);
+                            yaz0.Encode2(ArcExtractPath + "arc", new BinaryReader(memst));
+
+                            memst.Close();
+                        }
 
 
 

--- a/ARCTool/Program.cs
+++ b/ARCTool/Program.cs
@@ -19,7 +19,8 @@ namespace ARCTool
         private static string[] all_path_strings;
         private static string[] arc_path_strings;
         private static string[] dir_path_strings;
-        private static char yesno = 'n';
+        private static Yaz0.UseStatus yaz0EncodeStatus = Yaz0.UseStatus.UnUse;
+        private static bool isOptimize = false;
 
         public static void Main(string[] args)
         {
@@ -78,7 +79,11 @@ namespace ARCTool
                 {
                     if (isFirstTime)
                     {
-                        yesno = Yaz0.Use_Yaz0_Encode();
+                        yaz0EncodeStatus = Yaz0.Use_Yaz0_Encode();
+                        if (yaz0EncodeStatus is Yaz0.UseStatus.UseNew)
+                        {
+                            isOptimize = Yaz0.Use_Yaz0_Encode_Optimize();
+                        }
                         isFirstTime = false;
                     }
 
@@ -97,36 +102,37 @@ namespace ARCTool
                     RARC rarc = new();
 
                     var ArcExtractPath = arcfolder + @"\" + arcfile;
-                    if (yesno == 'y' || yesno == 'Y' || yesno == 'ｙ' || yesno == 'Ｙ')
+                    if (yaz0EncodeStatus is Yaz0.UseStatus.UseNew)
                     {
-                        if (isUseOtherExefile)
+                        MemoryStream memst = new();
+
+                        memst.Seek(0, SeekOrigin.Begin);
+                        rarc.Archive(new BinaryWriter(memst), DirStrs, FileStrs);
+                        Console.WriteLine("yaz0処理に入りました");
+                        Console.WriteLine("圧縮中・・・");
+
+                        memst.Seek(0, SeekOrigin.Begin);
+                        if (isOptimize)
                         {
-                            rarc.Archive(ArcExtractPath + ".rarc", DirStrs, FileStrs);
-                            Console.WriteLine("yaz0処理に入りました");
-                            Console.WriteLine("圧縮中・・・");
-                            AppExecuter.Start(arcfolder + @"\" + arcfile + ".rarc");
-                            //Yaz0 yaz0 = new();
-                            //yaz0.Encode2(arcfolder + @"\" + arcfile + ".rarc");
+                            yaz0.EncodeOptimize(Path.ChangeExtension(ArcExtractPath, "arc"), new BinaryReader(memst));
                         }
                         else
                         {
-                            MemoryStream memst = new();
-
-                            memst.Seek(0, SeekOrigin.Begin);
-                            rarc.Archive(new BinaryWriter(memst), DirStrs, FileStrs);
-                            Console.WriteLine("yaz0処理に入りました");
-                            Console.WriteLine("圧縮中・・・");
-
-                            memst.Seek(0, SeekOrigin.Begin);
-                            yaz0.Encode2(ArcExtractPath + "arc", new BinaryReader(memst));
-
-                            memst.Close();
+                            yaz0.Encode(Path.ChangeExtension(ArcExtractPath, "arc"), new BinaryReader(memst));
                         }
 
-
+                        memst.Close();
 
                         Console.WriteLine("Yaz0圧縮できました");
-                        //Console.ReadKey();
+                        continue;
+                    }
+                    else if (yaz0EncodeStatus is Yaz0.UseStatus.Use)
+                    {
+                        rarc.Archive(ArcExtractPath + ".rarc", DirStrs, FileStrs);
+                        Console.WriteLine("yaz0処理に入りました");
+                        Console.WriteLine("圧縮中・・・");
+                        AppExecuter.Start(arcfolder + @"\" + arcfile + ".rarc");
+                        Console.WriteLine("Yaz0圧縮できました");
                         continue;
                     }
 


### PR DESCRIPTION
Hide WhitespaceするとVisualStudioで見た時と同じdiffになります。

[Yaz0圧縮の実装とそれに伴いRARC関数をStreamでの受け渡し可能にする。](https://github.com/penguin117117/ARCTool/commit/343b99518ea525b69251ce136f05a7525dbc94eb)では、
- RARC.Archive()関数はStream受け渡しを可能にする
  - 従来の関数として使用することのできるラッパの実装
- Yaz0圧縮とそれに伴うクラスの実装
  - Yaz0Unitは圧縮データ(生値または圧縮オフセットと長さ)を保持し、</br>その情報から圧縮値を生成するクラスです。
  - Yaz0ChunkはYaz0Unitを8つ生成してその情報を保持し、</br>その情報から圧縮情報を生成します。

[圧縮オプションの追加とYaz0.Encode部の関数分け](https://github.com/penguin117117/ARCTool/commit/7c6f0fce91fcaf2d171387e5d1f7d3a5429b40d3)では、
UIの変更が含まれます。
圧縮時に大文字のYを入力することで今回実装したYaz0圧縮を使用できます。