### PR TITLE
unsafeエンコーダの作成

### DIFF
--- a/ARCTool/FileSys/Yaz0.cs
+++ b/ARCTool/FileSys/Yaz0.cs
@@ -263,14 +263,6 @@ namespace ARCTool.FileSys
             Yaz0Chunk chunk = new Yaz0ChunkRawEncode(br);
             bw.Write(chunk.GetValue());
 
-            ////チャンクデータの読み込み方法を設定
-            //while (br.BaseStream.Position < br.BaseStream.Length)
-            //{
-            //    chunk = new Yaz0ChunkEncode(br);
-            //    bw.Write(chunk.GetValue());
-            //}
-            ////チャンクデータの読み込み方法を設定_END
-
             List<Yaz0Unit> buffer = new();
             //チャンクデータの読み込み方法を設定
             while (br.BaseStream.Position < br.BaseStream.Length)

--- a/ARCTool/FileSys/Yaz0.cs
+++ b/ARCTool/FileSys/Yaz0.cs
@@ -251,6 +251,28 @@ namespace ARCTool.FileSys
                 bw.Write(padding);
             }
         }
+        public void EncodeOptimizeV2(BinaryWriter bw, BinaryReader br)
+        {
+            //ヘッダー情報の書き込み
+            Console.WriteLine("write header");
+            HeaderWriter(bw, br.BaseStream.Length);
+
+            Console.WriteLine("write chunk");
+
+            Yaz0Encode encoder = new();
+            encoder.Encode(bw, br);
+
+            Console.WriteLine("write padding");
+            PaddingWriter(bw);
+
+            Console.WriteLine($"Stream End Pos: {br.BaseStream.Position}");
+        }
+        public void EncodeOptimizeV2(string encodeFilePath, BinaryReader br)
+        {
+            FileStream fs = new(encodeFilePath, FileMode.Create);
+            EncodeOptimizeV2(new BinaryWriter(fs), br);
+            fs.Close();
+        }
 
         public void EncodeOptimize(BinaryWriter bw, BinaryReader br)
         {

--- a/ARCTool/FileSys/Yaz0Encode.cs
+++ b/ARCTool/FileSys/Yaz0Encode.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ARCTool.FileSys
+{
+    internal unsafe class Yaz0Encode
+    {
+        private const int Byte2_Additional_Length = 0x2;
+        private const int Byte2_Max_Dictionary_Length =
+            (0xF000 >> 12) + Byte2_Additional_Length;              //byte2時の辞書サイズ
+
+        private const int Byte3_Additional_Length = Byte2_Max_Dictionary_Length + 1;
+        private const int Byte3_Max_Dictionary_Length =
+            0x0000FF + Byte3_Additional_Length;                    //byte2時の辞書サイズ
+
+        private const int Max_Dictionary_Offset = 0x0FFF; //辞書の最大サイズ
+
+        unsafe
+        private class Unit
+        {
+            public long Length;
+            public long Offset;
+
+            private long CompressSize()
+            {
+                if (Length >= Byte3_Additional_Length)
+                    return 0x03;
+
+                if (Length > Byte2_Additional_Length)
+                    return 0x02;
+
+                return 0x01;
+            }
+
+            public int Score(long skipCount)
+            {
+                Debug.Assert(Length > 0);
+                return (int)Length - (int)(CompressSize() + skipCount);
+            }
+
+            public void Init()
+            {
+                // Lengthが1となっていますが、
+                // その場合はraw値が書き込まれるため
+                // バイナリへの影響はありません。
+                Length = 1;
+                Offset = 0;
+            }
+
+            public long Write(byte* flag, int writeFlagCount, byte* dst, in long pos, byte* src, in long srcPos)
+            {
+                if (Length > Byte2_Additional_Length)
+                {   // 2byte or 3byte
+                    dst[pos] = (byte)((0x0F00 & Offset) >> 0x08);
+                    dst[pos + 1] = (byte)(0x00FF & Offset);
+
+                    long length = 0;
+                    if (Length >= Byte3_Additional_Length)
+                    {   // 3byte
+                        length = Length - Byte3_Additional_Length;
+                        dst[pos + 2] = (byte)length;
+                        return 0x03;
+                    }
+
+                    length = Length - Byte2_Additional_Length;
+                    dst[pos] |= (byte)(0xF0 & (length << 0x04));
+                    return 0x02;
+                }
+
+                Length = 1;
+                *flag |= (byte)(0b1000_0000 >> writeFlagCount);
+                dst[pos] = src[srcPos];
+                return 0x01;
+            }
+        }
+
+        private unsafe void GenUnit(Unit dst, in byte* data, in long size, in long pos)
+        {
+            dst.Init();
+            long dictBeginOffset = Math.Min(pos, Max_Dictionary_Offset + 1);
+            long maxCompSize = Math.Min(Byte3_Max_Dictionary_Length, size - pos);
+
+            for (long dictPos = pos - dictBeginOffset; dictPos < pos; dictPos++)
+            {
+                long length = 0;
+                while (length < maxCompSize)
+                {
+                    if (data[dictPos + length] != data[pos + length])
+                        break;
+                    length++;
+                }
+
+                if (length <= dst.Length)
+                    continue;
+
+                dst.Length = length;
+                dst.Offset = dictPos;
+            }
+
+            Debug.Assert(dst.Length > 0);
+
+            dst.Offset = (pos - 1) - dst.Offset;
+        }
+
+        private unsafe long Encode(byte* dst, in byte* src, in long size)
+        {
+            long dstPos = 0;
+            long srcPos = 0;
+            // 先頭の値は8バイト圧縮され"ます"(yaz0enc.exeより)。
+
+            byte flag = 0x00;
+            long flagPos = dstPos;
+            int writeFlagCount = 8;
+
+            Unit currentUnit = new();
+            Unit nextUnit = new();
+            bool isNextUnitValid = false;
+            long skipCount = 0;
+
+            while (srcPos < size)
+            {
+                if (writeFlagCount == 8)
+                {
+                    dst[flagPos] = flag;
+                    flag = 0x00;
+                    flagPos = dstPos;
+                    writeFlagCount = 0x00;
+                    dstPos++;
+                }
+
+                if (isNextUnitValid)
+                {
+                    // 参照先の交換
+                    // やっていることはポインタの交換と同じ。
+                    var buffer = currentUnit;
+                    currentUnit = nextUnit;
+                    nextUnit = buffer;
+                }
+                else
+                {
+                    GenUnit(currentUnit, src, size, srcPos);
+                }
+
+                GenUnit(nextUnit, src, size, srcPos + 1);
+
+                if (currentUnit.Score(skipCount) < nextUnit.Score(skipCount + 1))
+                {
+                    flag |= (byte)(0b1000_0000 >> writeFlagCount);
+                    dst[dstPos] = src[srcPos];
+                    dstPos++;
+                    srcPos++;
+                    skipCount++;
+                    isNextUnitValid = true;
+                }
+                else
+                {
+                    var dstSize = currentUnit.Write(&flag, writeFlagCount, dst, dstPos, src, srcPos);
+                    dstPos += dstSize;
+                    srcPos += currentUnit.Length;
+                    skipCount = 0;
+                    isNextUnitValid = false;
+                }
+
+                writeFlagCount++;
+            }
+
+            dst[flagPos] = flag;
+
+            return dstPos;
+        }
+
+        public void Encode(BinaryWriter bw, BinaryReader br)
+        {
+            var src = new byte[br.BaseStream.Length];
+            var dst = new byte[br.BaseStream.Length];
+            br.Read(src);
+
+            long dstSize = 0;
+
+            fixed (byte* pDst = dst, pSrc = src)
+                dstSize = Encode(pDst, pSrc, br.BaseStream.Length);
+
+            bw.Write(dst, 0, (int)dstSize);
+        }
+    }
+}

--- a/ARCTool/FileSys/Yaz0Unit.cs
+++ b/ARCTool/FileSys/Yaz0Unit.cs
@@ -131,23 +131,24 @@ namespace ARCTool.FileSys
 
         public Yaz0UnitEncode(BinaryReader br)
         {
-            var dictionary = new byte[Dictionary_Buffer_Size];
+            // 辞書と圧縮されるデータをここに格納します。
+            var buffer = new byte[Dictionary_Buffer_Size];
             List<long> matchOffsetBuffer = new();
 
             var basePosition = br.BaseStream.Position;
 
-            long dictionaryBaseSize = Math.Min(basePosition, Max_Dictionary_Offset);
+            long targetPosInBuf = Math.Min(basePosition, Max_Dictionary_Offset);
 
-            br.BaseStream.Seek(basePosition - dictionaryBaseSize, SeekOrigin.Begin);
+            br.BaseStream.Seek(basePosition - targetPosInBuf, SeekOrigin.Begin);
 
-            var compressSize = br.BaseStream.Read(dictionary) - dictionaryBaseSize;
+            var compressSize = br.BaseStream.Read(buffer) - targetPosInBuf;
             compressSize = Math.Min(compressSize, Byte3_Max_Dictionary_Length);
 
             br.BaseStream.Seek(basePosition, SeekOrigin.Begin);
 
-            foreach (var i in Enumerable.Range(0, (int)dictionaryBaseSize))
+            foreach (var i in Enumerable.Range(0, (int)targetPosInBuf))
             {
-                if (dictionary[i] != dictionary[dictionaryBaseSize])
+                if (buffer[i] != buffer[targetPosInBuf])
                     continue;
 
                 matchOffsetBuffer.Add(i);
@@ -170,7 +171,7 @@ namespace ARCTool.FileSys
                 int length = 1;
                 while (length < compressSize)
                 {
-                    if (dictionary[targetDictOffset + length] != dictionary[dictionaryBaseSize + length])
+                    if (buffer[targetDictOffset + length] != buffer[targetPosInBuf + length])
                         break;
                     length++;
                 }
@@ -185,7 +186,7 @@ namespace ARCTool.FileSys
             if (currentLength > Byte2_Additional_Length)
             {
                 br.BaseStream.Seek(basePosition + currentLength, SeekOrigin.Begin);
-                Initializer((dictionaryBaseSize - 1) - currentPos, currentLength);
+                Initializer((targetPosInBuf - 1) - currentPos, currentLength);
                 return;
             }
 

--- a/ARCTool/Program.cs
+++ b/ARCTool/Program.cs
@@ -114,7 +114,7 @@ namespace ARCTool
                         memst.Seek(0, SeekOrigin.Begin);
                         if (isOptimize)
                         {
-                            yaz0.EncodeOptimize(Path.ChangeExtension(ArcExtractPath, "arc"), new BinaryReader(memst));
+                            yaz0.EncodeOptimizeV2(Path.ChangeExtension(ArcExtractPath, "arc"), new BinaryReader(memst));
                         }
                         else
                         {


### PR DESCRIPTION
これに伴い、Yaz0圧縮(新)を使用時の最適化エンコードを
今回実装したunsafe実装に変更しています。

また、#3 の際の
- 消し忘れていた不要なコメントの削除
- 間違った解釈を与える可能性のある変数名の変更
も含まれます。